### PR TITLE
Set up Cursor Cloud dev environment (docs + startup script)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,23 @@ Rules:
 - If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+
+## Cursor Cloud specific instructions
+
+This is the **Miroir Framework**, an npm-workspaces monorepo (packages/*, Node 20+/22, `package-lock.json`). The update script runs `npm install` plus a fix for npm optional-dependency bug #4828 (a plain `npm install` fails to install `@rollup/rollup-linux-x64-gnu`, so `miroir-core`/Vite builds crash with "Cannot find module @rollup/rollup-linux-x64-gnu"). If you hit that error after a manual install, run `npm install --no-save @rollup/rollup-linux-x64-gnu@$(node -p "require('rollup/package.json').version")`.
+
+### Building
+- Standard build order/commands live in `build-all.sh` and `docs/guides/build-it-yourself.md`; per-package scripts are in each `package.json`.
+- Known caveat (see issue #190, guide disclaims validation): the from-scratch **`.d.ts` (tsup `dts`) phase fails with a circular bootstrap between `miroir-core` and `miroir-test-app_deployment-*` (e.g. "has no exported member named 'JzodObject'"). The **runtime ESM output (`dist/index.js`) is still emitted for every package** before that phase fails, and Vite dev + vitest only need the JS. To get a runnable dev tree, build every workspace lib's JS tolerating the DTS non-zero exit (loop `npm run build -w <pkg>` over the deployment/core/localcache/store/react/diagram packages). Use `NODE_OPTIONS=--max-old-space-size=6144` for Vite/ncc steps.
+
+### Running the app (dev)
+- Two services: `miroir-server` (REST API + AI/MCP, port 3080) and `miroir-standalone-app` (React SPA via Vite, port 5173). The web client is hardcoded to `miroirConfigRealServerFilesystemGit`, so it always expects the server at `https://localhost:3080` (filesystem store rooted at the repo, no Postgres needed).
+- `miroir-server` has **no dev script**; build a bundle once with `npm run build:server -w miroir-server` then `npm run copy:release-config -w miroir-server`. It also needs `miroir-ai` built (`npm run build -w miroir-ai`).
+- Run the server **API-only** with `NODE_ENV=development` (in `prod` mode it refuses to start unless a built client exists at `release/client`): from `packages/miroir-server`, `NODE_EXTRA_CA_CERTS=$(mkcert -CAROOT)/rootCA.pem NODE_ENV=development node release/index.js`. Then run the client: `npm run dev -w miroir-standalone-app`.
+- TLS: run `bash scripts/setup-https.sh` (needs `mkcert`) to create `certs/`; both server and Vite auto-enable HTTPS when certs exist. The client calls the server **cross-origin** at `https://localhost:3080`, so Chrome must trust the mkcert CA — add it to Chrome's NSS store (`certutil -d sql:$HOME/.local/share/pki/nssdb -A -t "C,," -n mkcert -i $(mkcert -CAROOT)/rootCA.pem`) and restart Chrome, otherwise background fetches fail silently.
+- GUI data caveat: with the shipped `miroirConfigRealServerFilesystemGit` web config the SPA renders but the "Application" selector stays empty — the client does not auto-fetch the deployment list (no calls to :3080 on load). The server engine itself works; verify/drive it via the REST API, e.g. `GET https://localhost:3080/CRUD/<deploymentUuid>/<model|data>/entity/<entityUuid>/all` and create/delete via `POST`/`DELETE https://localhost:3080/CRUD/<deploymentUuid>/<section>/entity` with body `{"deploymentUuid":"...","crudInstances":[<instance>]}`. Known deployment UUIDs: Miroir `10ff36f2-50a3-48d8-b80f-e48e5d13af8e`, Admin `18db21bf-f8d3-4f6a-8296-84b69f6dc48b`; the meta "Entity" entity is `16dbfe28-e1d7-4f20-9ba4-c1a9873202ad`.
+
+### Tests / typecheck
+- The `nonreg` npm scripts invoke `python` (not `python3`); `python-is-python3` is installed in this environment.
+- `npm run nonreg:unit` runs the no-dependency unit tier (passes). The `default`/integration tiers need Postgres (`postgres://postgres:postgres@localhost:5432/postgres`) or a specific store profile; run them via the runner with `python scripts/run-nonreg.py --tier default --profile <emulatedServer-filesystem|emulatedServer-sql> --only <stepId>` **from the repo root** (profile configs resolve paths relative to `process.env.PWD`, and several test/CI configs contain hardcoded `/build/...` or personal absolute paths).
+- There is no ESLint config; `npm run typecheck` (`tsc --noEmit`) is the closest gate and currently reports ~31 pre-existing type errors (mostly `miroir-standalone-app` tests/views and `miroir-sandbox`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Miroir Framework monorepo in Cursor Cloud and documents the non-obvious startup/run caveats discovered along the way. The only code change is an addition to `AGENTS.md`; the rest is captured in the VM update script and one-off environment setup.

## What I did

- Installed dependencies. Worked around npm optional-dependency bug #4828 — a plain `npm install` does not install `@rollup/rollup-linux-x64-gnu` (triggered by `libc` fields in the committed lockfile), which crashes `miroir-core`/Vite builds. The update script adds a guarded reinstall of the matching native binary.
- Built the runtime JS (`dist/index.js`) for all workspace packages. The from-scratch `.d.ts` (tsup `dts`) phase has a pre-existing circular bootstrap between `miroir-core` and `miroir-test-app_deployment-*` (matches the build guide disclaimer / issue #190), but the ESM runtime output is emitted for every package, which is all Vite dev + vitest need.
- Ran both services: `miroir-server` (REST API, `:3080`, HTTPS) and `miroir-standalone-app` (React SPA via Vite, `:5173`, HTTPS). Generated locally-trusted certs with mkcert and trusted the CA in Chrome's NSS store.
- Verified the running app end-to-end via its REST API (create → read → delete of an entity instance), and confirmed the unit test tier passes.

## Update script (dependency refresh)

```
npm install
node -e "const v=require('rollup/package.json').version; try { require('@rollup/rollup-linux-x64-gnu'); } catch (e) { require('child_process').execSync('npm install --no-save @rollup/rollup-linux-x64-gnu@'+v, {stdio:'inherit'}); }"
```

One-off system setup (persisted via snapshot, intentionally NOT in the update script): `mkcert` + `libnss3-tools`, `python-is-python3` (the `nonreg` scripts call `python`).

## Verification

| Concern | Service | Command | Result |
|---|---|---|---|
| Tests | miroir-core + standalone-app | `npm run nonreg:unit` | 4 passed / 0 failed |
| Lint/typecheck | monorepo | `npm run typecheck` | runs; ~31 pre-existing errors (no ESLint config in repo) |
| Build (runtime JS) | all packages | `npm run build -w <pkg>` | `dist/index.js` emitted for every lib |
| Run backend | miroir-server | `NODE_ENV=development node release/index.js` | HTTPS `:3080`, loads Miroir+Admin deployments |
| Run frontend | miroir-standalone-app | `npm run dev -w miroir-standalone-app` | Vite HTTPS `:5173`, SPA renders |
| Hello-world | live server | REST `POST`/`GET`/`DELETE /CRUD/...` | created + read back + deleted `HelloWorldMiroir` instance |

Hello-world (mutating action against the running app's core CRUD engine):

```
CREATE  POST /CRUD/10ff36f2.../data/entity        -> HTTP 200
READ    GET  /CRUD/10ff36f2.../data/entity/a659d350.../all -> "HelloWorldMiroir" present (2 instances)
DELETE  DELETE /CRUD/10ff36f2.../data/entity       -> HTTP 200, instance gone (1 instance); git clean
```

Running SPA:

[Miroir SPA running via Vite dev server](https://cursor.com/agents/bc-ae4e5303-0c0a-4eff-99ad-0af47bd3bc12/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmiroir_spa_running.webp)

## Notes / caveats (documented in AGENTS.md)
- The shipped web config (`miroirConfigRealServerFilesystemGit`) renders the SPA but does not auto-populate the "Application" selector (the client makes no deployment fetch on load); the server engine works and is drivable via the REST API.
- The full `.d.ts` build and the default/integration test tier (Postgres or hardcoded CI/personal paths) are pre-existing repo limitations, not environment issues.
- `npm run typecheck` reports ~31 pre-existing type errors; left untouched (no source changes).

Please merge the `AGENTS.md` updates so future cloud agents remember these non-obvious startup caveats next time.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae4e5303-0c0a-4eff-99ad-0af47bd3bc12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae4e5303-0c0a-4eff-99ad-0af47bd3bc12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

